### PR TITLE
Portfolio: preserve data in the browser

### DIFF
--- a/script.js
+++ b/script.js
@@ -248,8 +248,6 @@ contactForm.addEventListener('submit', function(){
   localStorage.setItem('storeData', JSON.stringify(storeData));
 });
 
-// contactForm.addEventListener('submit', formData);
-
 window.onload = function() {
   const data = JSON.parse(localStorage.getItem('storeData'));
   if(data) {

--- a/script.js
+++ b/script.js
@@ -237,12 +237,12 @@ function formValidate(event) {
 contactForm.addEventListener('submit', formValidate);
 
 // Preserve data in browsers
-
 function formData() {
   storeData = {
     storeName: fullName.value,
     storeEmail: email.value,
     storeMessage: message.value,
+    storeMessage: email.value,
   };
   localStorage.setItem('storeData', JSON.stringify(storeData));
 }

--- a/script.js
+++ b/script.js
@@ -237,17 +237,27 @@ function formValidate(event) {
 contactForm.addEventListener('submit', formValidate);
 
 // Preserve data in browsers
-function formData() {
+
+// function formData() {
+//   storeData = {
+//     storeName: fullName.value,
+//     storeEmail: email.value,
+//     storeMessage: message.value,
+//     storeMessage: email.value,
+//   };
+//   localStorage.setItem('storeData', JSON.stringify(storeData));
+// }
+contactForm.addEventListener('submit', function(){
   storeData = {
     storeName: fullName.value,
     storeEmail: email.value,
     storeMessage: message.value,
-    storeMessage: email.value,
+    // storeMessage: email.value,
   };
   localStorage.setItem('storeData', JSON.stringify(storeData));
-}
+});
 
-contactForm.addEventListener('submit', formData);
+// contactForm.addEventListener('submit', formData);
 
 window.onload = function() {
   const data = JSON.parse(localStorage.getItem('storeData'));

--- a/script.js
+++ b/script.js
@@ -237,23 +237,20 @@ function formValidate(event) {
 contactForm.addEventListener('submit', formValidate);
 
 // Preserve data in browsers
-
-contactForm.addEventListener('submit', function(){
-  storeData = {
+contactForm.addEventListener('submit', () => {
+  const storeData = {
     storeName: fullName.value,
     storeEmail: email.value,
     storeMessage: message.value,
-    // storeMessage: email.value,
   };
   localStorage.setItem('storeData', JSON.stringify(storeData));
 });
 
-window.onload = function() {
+window.onload = function dataLoad() {
   const data = JSON.parse(localStorage.getItem('storeData'));
-  if(data) {
+  if (data) {
     fullName.value = data.storeName;
     email.value = data.storeEmail;
     message.value = data.storeMessage;
   }
-  }
-
+};

--- a/script.js
+++ b/script.js
@@ -238,15 +238,19 @@ contactForm.addEventListener('submit', formValidate);
 
 // Preserve data in browsers
 
-// function formData() {
-//   storeData = {
-//     storeName: fullName.value,
-//     storeEmail: email.value,
-//     storeMessage: message.value,
-//     storeMessage: email.value,
-//   };
-//   localStorage.setItem('storeData', JSON.stringify(storeData));
-// }
+//  remover f
+function formData() {
+  storeData = {
+    storeName: fullName.value,
+    storeEmail: email.value,
+    storeMessage: message.value,
+    storeMessage: email.value,
+  };
+  localStorage.setItem('storeData', JSON.stringify(storeData));
+}
+
+// up to this 
+
 contactForm.addEventListener('submit', function(){
   storeData = {
     storeName: fullName.value,

--- a/script.js
+++ b/script.js
@@ -238,19 +238,6 @@ contactForm.addEventListener('submit', formValidate);
 
 // Preserve data in browsers
 
-//  remover f
-function formData() {
-  storeData = {
-    storeName: fullName.value,
-    storeEmail: email.value,
-    storeMessage: message.value,
-    storeMessage: email.value,
-  };
-  localStorage.setItem('storeData', JSON.stringify(storeData));
-}
-
-// up to this 
-
 contactForm.addEventListener('submit', function(){
   storeData = {
     storeName: fullName.value,

--- a/script.js
+++ b/script.js
@@ -235,3 +235,26 @@ function formValidate(event) {
 }
 
 contactForm.addEventListener('submit', formValidate);
+
+// Preserve data in browsers
+
+function formData() {
+  storeData = {
+    storeName: fullName.value,
+    storeEmail: email.value,
+    storeMessage: message.value,
+  };
+  localStorage.setItem('storeData', JSON.stringify(storeData));
+}
+
+contactForm.addEventListener('submit', formData);
+
+window.onload = function() {
+  const data = JSON.parse(localStorage.getItem('storeData'));
+  if(data) {
+    fullName.value = data.storeName;
+    email.value = data.storeEmail;
+    message.value = data.storeMessage;
+  }
+  }
+


### PR DESCRIPTION
In this part of the portfolio, I implemented the following interactions:

- When the user changes the content of any input field, the data is saved to the local storage.
- When the user loads the page, if there is any data in the local storage, the input fields are pre-filled with this data.